### PR TITLE
Add X-Api-Key support for Caddy authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -174,3 +174,5 @@ cython_debug/
 # PyPI configuration file
 .pypirc
 test.py
+.DS_Store
+docs/

--- a/README.md
+++ b/README.md
@@ -20,7 +20,13 @@ This library simplifies working with the API by providing convenient controllers
 
 ## 📦 Installation
 
-Currently, the SDK is available via Git. You can install it directly using `pip`:
+You can install it directly using `pip`:
+
+```bash
+pip install remnawave_api
+```
+
+or with `pip` from git:
 
 ```bash
 pip install git+https://github.com/sm1ky/remnawave-api.git

--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@
 [![PyPi Package Version](https://img.shields.io/pypi/v/remnawave-api)](https://pypi.python.org/pypi/remnawave-api)
 [![Publish Python Package](https://github.com/sm1ky/remnawave-api/actions/workflows/upload.yml/badge.svg?branch=production)](https://github.com/sm1ky/remnawave-api/actions/workflows/upload.yml)
 
-A Python SDK client for interacting with the [Remnawave API](https://remna.st).
-This library simplifies working with the API by providing convenient controllers, Pydantic models for requests and responses, and fast serialization with `orjson`.
+A Python SDK client for interacting with the **[Remnawave API](https://remna.st)**.
+This library simplifies working with the API by providing convenient controllers, Pydantic models for requests and responses, and fast serialization with `orjson`. 
+Library checked with Remnawave **[v1.5.7](https://github.com/remnawave/panel/releases/tag/1.5.7)**
 
 ## ✨ Key Features
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "remnawave-api"
-version = "1.0.2"
+version = "1.0.3"
 description = "A Python SDK for interacting with the Remnawave API."
 authors = [
     {name = "Artem",email = "sm1ky@forestsnet.com"}

--- a/remnawave_api/__init__.py
+++ b/remnawave_api/__init__.py
@@ -30,10 +30,21 @@ class RemnawaveSDK:
         client: Optional[httpx.AsyncClient] = None,
         base_url: Optional[str] = None,
         token: Optional[str] = None,
+        caddy_token: Optional[str] = None,
     ):
+        """
+        Remnawave SDK init
+
+        Args:
+            client (Optional[httpx.AsyncClient]): - Default client. 
+            base_url (Optional[str]): - Base url of the Remnawave panel. Defaults to None.
+            token (Optional[str]): - Token for authorization. 
+            caddy_token (Optional[str]): - Token for Caddy Auth (Headers). Defaults to None.
+        """
         self._client = client
         self._token = token
         self.base_url = base_url
+        self.caddy_token = caddy_token
 
         self._validate_params()
 
@@ -76,13 +87,21 @@ class RemnawaveSDK:
         )
 
     def _prepare_headers(self) -> dict:
-        if not self._token.startswith("Bearer "):
-            self._token = "Bearer " + self._token
-        return {"Authorization": self._token}
+        headers = {}
+        if self._token:
+            headers["Authorization"] = (
+                self._token if self._token.startswith("Bearer ") else f"Bearer {self._token}"
+            )
+        
+        # X-Api-Key for Caddy (https://remna.st/security/caddy-with-custom-path#issuing-api-keys)
+        if self.caddy_token is not None:
+            headers["X-Api-Key"] = self.caddy_token
+        
+        return headers
 
     def _prepare_url(self) -> str:
         if self.base_url.endswith("/"):
-            self.base_url[:-1]
+            self.base_url = self.base_url[:-1]
 
         if not self.base_url.endswith("/api"):
             self.base_url += "/api"


### PR DESCRIPTION
Enhance the SDK to include a `caddy_token` for secure API access via the `X-Api-Key` header. Update installation instructions in the README for clarity. Increment version to 1.0.3 to reflect these changes.

From Issue #6