### PR TITLE
Bump version to 1.0.5 and refactor pagination parameters

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "remnawave-api"
-version = "1.0.4"
+version = "1.0.5"
 description = "A Python SDK for interacting with the Remnawave API."
 authors = [
     {name = "Artem",email = "sm1ky@forestsnet.com"}

--- a/remnawave_api/controllers/users.py
+++ b/remnawave_api/controllers/users.py
@@ -1,6 +1,6 @@
 from typing import Annotated
 
-from rapid_api_client import Path, Query
+from rapid_api_client import Path
 from rapid_api_client.annotations import PydanticBody
 
 from remnawave_api.models import (
@@ -35,8 +35,8 @@ class UsersController(BaseController):
     @get("/users/v2", response_class=UsersResponseDto)
     async def get_all_users_v2(
         self,
-        size: Annotated[int, Query(100, description="Size of the page")],
-        start: Annotated[int, Query(0, description="Start index of the page")],
+        size: int = 100,
+        start: int = 0
     ) -> UsersResponseDto:
         """
         Get a paginated list of users.


### PR DESCRIPTION
Update the version in `pyproject.toml` to 1.0.5 and refactor the `UsersController` to use default parameters for pagination, simplifying the API usage.