### PR TITLE
Remove unnecessary parameters and update version to 1.0.7 with webhook validation utility

### DIFF
--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -48,6 +48,3 @@ jobs:
       - name: Publish package
         if: ${{ !contains(github.event.head_commit.message, '[skip publish]') }}
         uses: pypa/gh-action-pypi-publish@v1.12.4
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "remnawave-api"
-version = "1.0.6"
+version = "1.0.7"
 description = "A Python SDK for interacting with the Remnawave API."
 authors = [
     {name = "Artem",email = "sm1ky@forestsnet.com"}

--- a/remnawave_api/__init__.py
+++ b/remnawave_api/__init__.py
@@ -21,6 +21,8 @@ from remnawave_api.controllers import (
     UsersController,
     UsersStatsController,
     XrayConfigController,
+    WebhookUtility,
+    # WebhookUtility is not a controller, but it's included in the controllers module for convenience
 )
 
 

--- a/remnawave_api/controllers/__init__.py
+++ b/remnawave_api/controllers/__init__.py
@@ -15,6 +15,7 @@ from .users import UsersController
 from .users_bulk_actions import UsersBulkActionsController
 from .users_stats import UsersStatsController
 from .xray_config import XrayConfigController
+from .webhooks import WebhookUtility
 
 __all__ = [
     "APITokensManagementController",
@@ -34,4 +35,5 @@ __all__ = [
     "UsersBulkActionsController",
     "UsersStatsController",
     "XrayConfigController",
+    "WebhookUtility"
 ]

--- a/remnawave_api/controllers/webhooks.py
+++ b/remnawave_api/controllers/webhooks.py
@@ -1,0 +1,32 @@
+import hmac
+import hashlib
+import json
+from typing import Union
+
+class WebhookUtility:
+    @staticmethod
+    def validate_webhook(
+        body: Union[str, dict],
+        signature: str,
+        webhook_secret: str
+    ) -> bool:
+        """
+        Validates the webhook's authenticity using HMAC SHA-256.
+
+        :param body: The webhook request body (either a JSON string or a parsed dictionary).
+        :param signature: The signature received from the server.
+        :param webhook_secret: The secret key used to compute the HMAC.
+        :return: True if the signature matches, otherwise False.
+        """
+        if isinstance(body, str):
+            original_body = body
+        else:
+            original_body = json.dumps(body, separators=(',', ':'))
+
+        computed_signature = hmac.new(
+            webhook_secret.encode('utf-8'),
+            original_body.encode('utf-8'),
+            hashlib.sha256
+        ).hexdigest()
+
+        return hmac.compare_digest(computed_signature, signature)


### PR DESCRIPTION
Streamline the PyPI publish action by removing unnecessary parameters and enable Trusted Publisher. Update the package version in `pyproject.toml` and introduce `WebhookUtility` for validating webhooks.