### PR TITLE
Remove mention of library check with Remnawave v1.6.0 from README.md [skip publish]

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@
 
 A Python SDK client for interacting with the **[Remnawave API](https://remna.st)**.
 This library simplifies working with the API by providing convenient controllers, Pydantic models for requests and responses, and fast serialization with `orjson`. 
-Library checked with Remnawave **[v1.6.0](https://github.com/remnawave/panel/releases/tag/1.6.0)**
 
 ## ✨ Key Features
 


### PR DESCRIPTION
Eliminate outdated reference to library compatibility with Remnawave v1.6.0 in the documentation.